### PR TITLE
Adding dogfriend 0.1.4

### DIFF
--- a/Library/Formula/dogfriend.rb
+++ b/Library/Formula/dogfriend.rb
@@ -1,13 +1,13 @@
 class Dogfriend < Formula
   desc "A command line utility for testing Chef changes"
   homepage "https://github.com/DataDog/dogfriend"
-  url "https://github.com/DataDog/dogfriend/releases/download/v0.1.4/dogfriend-0.1.4-darwin-x86_64.zip"
+  version '0.1.4'
+  url "http://devops-public.s3.amazonaws.com/dogfriend-#{ version }-darwin-x86_64.zip"
   sha256 "c4fd3ce0f296d94f811cf8b3388a4f2d126a4466a10ecc85ed22ef7858ce28ea"
 
   def install
-    unzip_dir = "dogfriend-0.1.4-darwin-x86_64"
-    prefix.install Dir["#{unzip_dir}/*"]
-    bin.install_symlink prefix+"dogfriend-0.1.4-darwin-x86_64" => "dogfriend"
+    prefix.install Dir["*"]
+    bin.install_symlink prefix+"dogfriend-#{ version }-darwin-x86_64" => "dogfriend"
   end
 
   test do

--- a/Library/Formula/dogfriend.rb
+++ b/Library/Formula/dogfriend.rb
@@ -1,0 +1,16 @@
+class Dogfriend < Formula
+  desc "A command line utility for testing Chef changes"
+  homepage "https://github.com/DataDog/dogfriend"
+  url "https://github.com/DataDog/dogfriend/releases/download/v0.1.4/dogfriend-0.1.4-darwin-x86_64.zip"
+  sha256 "c4fd3ce0f296d94f811cf8b3388a4f2d126a4466a10ecc85ed22ef7858ce28ea"
+
+  def install
+    unzip_dir = "dogfriend-0.1.4-darwin-x86_64"
+    prefix.install Dir["#{unzip_dir}/*"]
+    bin.install_symlink prefix+"dogfriend-0.1.4-darwin-x86_64" => "dogfriend"
+  end
+
+  test do
+    system "#{bin}/dogfriend readme"
+  end
+end


### PR DESCRIPTION
`dogfriend` is a command line client utility for managing changes to Chef, somewhat like an "opinionated knife" utility for assisting with Chef development at Datadog.

https://github.com/datadog/dogfriend
